### PR TITLE
darling-dmg do not handle well dmg with fUDIFDataForkOffset != 0

### DIFF
--- a/src/DMGDisk.cpp
+++ b/src/DMGDisk.cpp
@@ -11,6 +11,7 @@
 #include "AppleDisk.h"
 #include "GPTDisk.h"
 #include "CachedReader.h"
+#include "SubReader.h"
 #include "exceptions.h"
 
 DMGDisk::DMGDisk(std::shared_ptr<Reader> reader)
@@ -232,11 +233,24 @@ std::shared_ptr<Reader> DMGDisk::readerForPartition(int index)
 		if (be(table->firstSectorNumber)*512 == m_partitions[index].offset)
 		{
 			std::stringstream partName;
+			uint64_t l = m_reader->length();
+			uint32_t data_offset = be(m_udif.fUDIFDataForkOffset);
+
 			partName << "part-" << index;
 
-			return std::shared_ptr<Reader>(
+			if (data_offset) {
+				std::shared_ptr<Reader> r(new SubReader(m_reader,
+					data_offset,
+					m_reader->length() - data_offset));
+
+				return std::shared_ptr<Reader>(
+						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(r, table)), &m_zone, partName.str())
+						);
+			} else {
+				return std::shared_ptr<Reader>(
 						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(m_reader, table)), &m_zone, partName.str())
-			);
+						);
+			}
 		}
 		
 		delete table;

--- a/src/DMGDisk.cpp
+++ b/src/DMGDisk.cpp
@@ -17,20 +17,19 @@ DMGDisk::DMGDisk(std::shared_ptr<Reader> reader)
 	: m_reader(reader), m_zone(40000)
 {
 	uint64_t offset = m_reader->length();
-	UDIFResourceFile udif;
 
 	if (offset < 512)
 		throw io_error("File to small to be a DMG");
 
 	offset -= 512;
 
-	if (m_reader->read(&udif, sizeof(udif), offset) != sizeof(udif))
+	if (m_reader->read(&m_udif, sizeof(m_udif), offset) != sizeof(m_udif))
 		throw io_error("Cannot read the KOLY block");
 
-	if (be(udif.fUDIFSignature) != UDIF_SIGNATURE)
+	if (be(m_udif.fUDIFSignature) != UDIF_SIGNATURE)
 		throw io_error("Invalid KOLY block signature");
 	
-	loadKoly(udif);
+	loadKoly(m_udif);
 }
 
 DMGDisk::~DMGDisk()

--- a/src/DMGDisk.h
+++ b/src/DMGDisk.h
@@ -27,6 +27,7 @@ private:
 private:
 	std::shared_ptr<Reader> m_reader;
 	std::vector<Partition> m_partitions;
+	UDIFResourceFile m_udif;
 	xmlDocPtr m_kolyXML;
 	CacheZone m_zone;
 };


### PR DESCRIPTION
When fUDIFDataForkOffset != 0, we can have this kind of error.

    ./darling-dmg-build/darling-dmg mount1/InstallESD.dmg mount2                                                                              
    Skipping partition of type Apple_Free
    Skipping partition of type Apple_partition_map
    Using partition #2 of type Apple_HFS
    readRun(): runIndex = 0, offsetInSector = 0, count = 1048576
    Error: Error decompressing stream
    
    Possible reasons:
    1) The file is corrupt.
    2) The file is not really a supported disk image, and needs further processing. The author has seen files with a .dmg extension, which were actually XAR archives containing a DMG.
    3) There is a bug in darling-dmg.

This could happen on file that are dual XAR/DMG (have a XAR header, and a DMG tail, and the content of both archives are not the same...)

So I guess the 2 & 3 reasons are linked for some file...

I made a patch by adding a SubReader when the offset is not null, maybe there are nicer way to do it.

(thanks to dmg2img which handled the files well and allow me to fix the bug here)