### PR TITLE
Include <functional> header containing the std::fuction definition.

### DIFF
--- a/src/main-fuse.cpp
+++ b/src/main-fuse.cpp
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <stdexcept>
 #include <limits>
+#include <functional>
 #include "HFSVolume.h"
 #include "AppleDisk.h"
 #include "GPTDisk.h"


### PR DESCRIPTION
Due to [a change in stdc++](https://gcc.gnu.org/gcc-7/porting_to.html#header-dep-changes) it is no longer pulled in by some of the other headers when compiled with GCC 7.1.0.