### PR TITLE
unicode string error

### DIFF
--- a/src/HFSAttributeBTree.cpp
+++ b/src/HFSAttributeBTree.cpp
@@ -3,7 +3,7 @@
 #include <stdexcept>
 #include <unicode/unistr.h>
 #include "unichar.h"
-
+using icu::UnicodeString;
 HFSAttributeBTree::HFSAttributeBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone)
 : HFSBTree(fork, zone, "Attribute")
 {

--- a/src/HFSCatalogBTree.cpp
+++ b/src/HFSCatalogBTree.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <cstring>
 #include "unichar.h"
-
+using icu::UnicodeString;
 static const int MAX_SYMLINKS = 50;
 
 extern UConverter *g_utf16be;

--- a/src/unichar.cpp
+++ b/src/unichar.cpp
@@ -5,7 +5,7 @@
 #include <unicode/errorcode.h>
 #include <cassert>
 #include <iostream>
-
+using icu::UnicodeString;
 UConverter *g_utf16be;
 
 static void InitConverter() __attribute__((constructor));


### PR DESCRIPTION
fixes #48 on Arch Linux