### PR TITLE
Incorrect read when compressed file on multiple extents.

### DIFF
--- a/src/HFSZlibReader.cpp
+++ b/src/HFSZlibReader.cpp
@@ -97,6 +97,7 @@ int32_t HFSZlibReader::readRun(int runIndex, void* buf, int32_t count, uint64_t 
 	// Decompress
 	char inputBuffer[512];
 	int32_t done = 0;
+	int32_t readCompressedSoFar = 0;
 	
 	while (done < count)
 	{
@@ -104,9 +105,12 @@ int32_t HFSZlibReader::readRun(int runIndex, void* buf, int32_t count, uint64_t 
 		int status, thistime;
 		
 		thistime = count - done;
+  
+		int thisTimeCompressed = std::min<uint64_t>(m_offsets[runIndex].second-readCompressedSoFar, sizeof(inputBuffer));
 		
 		if (!m_lastUncompressed)
-			read = m_reader->read(inputBuffer, sizeof(inputBuffer), m_inputPos + m_offsets[runIndex].first);
+			read = m_reader->read(inputBuffer, thisTimeCompressed, m_inputPos + m_offsets[runIndex].first);
+		readCompressedSoFar += read;
 		
 		// Special handling for uncompressed blocks
 		if (m_lastUncompressed || (done == 0 && read > 0 && (inputBuffer[0] & 0xf) == 0xf))


### PR DESCRIPTION
Algorithm to read ressources was a bit wrong.
It fails on compressed file with multiple extents. Because there is a header in ressource fork for compressed file, reads weren't align anymore with 4K blocks. The last read of the extent was reading too much data, feeding inflate incorrectly. I joined a dmg where these is a file named testfile_compressed_inflate_error.txt to test this.

Hope you'll take my pull requests and then correct the formatting issues if there is. To correct my formatting will be anyway a lot quicker than correcting this bug (was a hard one to spot), right ?

[DarlingForkBug.dmg.zip](https://github.com/darlinghq/darling-dmg/files/2111130/DarlingForkBug.dmg.zip)
