### PR TITLE
hfs_getxattr for Apple

### DIFF
--- a/src/main-fuse.cpp
+++ b/src/main-fuse.cpp
@@ -276,9 +276,16 @@ int hfs_readdir(const char* path, void* buf, fuse_fill_dir_t filler, off_t offse
 
 }
 
+#ifdef __APPLE__
+int hfs_getxattr(const char* path, const char* name, char* value, size_t vlen, uint32_t position)
+#else
 int hfs_getxattr(const char* path, const char* name, char* value, size_t vlen)
+#endif
 {
 	std::cerr << "hfs_getxattr(" << path << ", " << name << ")\n";
+#ifdef __APPLE__
+	if (position > 0) return -ENOSYS; // it's not supported... yet. I think it doesn't happen anymore since osx use less ressource fork
+#endif
 
 	return handle_exceptions([&]() -> int {
 		std::vector<uint8_t> data;

--- a/src/main-fuse.h
+++ b/src/main-fuse.h
@@ -13,7 +13,11 @@ int hfs_open(const char* path, struct fuse_file_info* info);
 int hfs_read(const char* path, char* buf, size_t bytes, off_t offset, struct fuse_file_info* info);
 int hfs_release(const char* path, struct fuse_file_info* info);
 int hfs_readdir(const char* path, void* buf, fuse_fill_dir_t filler, off_t offset, struct fuse_file_info* info);
-int hfs_getxattr(const char* path, const char* name, char* value, size_t vlen);
+#ifdef __APPLE__
+  int hfs_getxattr(const char* path, const char* name, char* value, size_t vlen, uint32_t unknown);
+#else
+  int hfs_getxattr(const char* path, const char* name, char* value, size_t vlen);
+#endif
 int hfs_listxattr(const char* path, char* buffer, size_t size);
 
 #endif


### PR DESCRIPTION
To compile on osx, one parameter more is needed for hfs_getxattr.

I know that darling_dmg is not suppose to be useful on Osx, but I'm testing on osx (which allow me to compare big images mounted by Osx and darling-dmg) and cross compile for linux.