### PR TITLE
Apple created date (or birthtime)

### DIFF
--- a/src/HFSHighLevelVolume.cpp
+++ b/src/HFSHighLevelVolume.cpp
@@ -313,6 +313,9 @@ void HFSHighLevelVolume::hfs_nativeToStat(const HFSPlusCatalogFileOrFolder& ff, 
 	assert(stat != nullptr);
 	memset(stat, 0, sizeof(*stat));
 
+#if defined(__APPLE__) && !defined(DARLING)
+	stat->st_birthtime = HFSCatalogBTree::appleToUnixTime(ff.file.createDate);
+#endif
 	stat->st_atime = HFSCatalogBTree::appleToUnixTime(ff.file.accessDate);
 	stat->st_mtime = HFSCatalogBTree::appleToUnixTime(ff.file.contentModDate);
 	stat->st_ctime = HFSCatalogBTree::appleToUnixTime(ff.file.attributeModDate);


### PR DESCRIPTION
Last in my serie of "Let's have an identical view of an HFS mount".

tested with rsync -a -X --crtimes -c on my test disk image (https://github.com/jief666/darling-dmg/blob/jief_wip/ImgTest.dmg) and on some very big sparsebundle (300GB - 400GB)
