### PR TITLE
wrong adc compression algorithm

### DIFF
--- a/src/DMGDecompressor.h
+++ b/src/DMGDecompressor.h
@@ -13,7 +13,7 @@ protected:
 	void processed(int bytes);
 public:
 	virtual ~DMGDecompressor() {}
-	virtual int32_t decompress(void* output, int32_t outputBytes) = 0;
+	virtual int32_t decompress(void* output, int32_t count, off_t offset) = 0;
 	
 	static DMGDecompressor* create(RunType runType, std::shared_ptr<Reader> reader);
 private:

--- a/src/adc.h
+++ b/src/adc.h
@@ -2,7 +2,7 @@
 #define ADC_H
 #include <stdint.h>
 
-int adc_decompress(int in_size, uint8_t* input, int avail_size, uint8_t* output, int* bytes_written);
+int adc_decompress(int in_size, uint8_t* input, int avail_size, uint8_t* output, int restartIndex, int* bytes_written);
 int adc_chunk_type(char _byte);
 int adc_chunk_size(char _byte);
 int adc_chunk_offset(unsigned char *chunk_start);


### PR DESCRIPTION
The adc compression function in adc.c wasn't design to handle block boundaries. One problem was when the input buffer contains a partial chunk at the end. Another big problem is that it's always needed to keep 65535 bytes before restart decompression in case of a lookback.

The solution used here is to read in a buffer that is 2 times bigger than 65535 (in fact, I used 65536) + the max size of a chunk. Each time decompression reach 65536*2, the second part of the buffer is shifted toward the beginning.

Because decompress takes now a 3rd arg (the offset), I've refactored a bit so decompress method for DMGDecompressor_Zlib and DMGDecompressor_Bzip2 takes also a 3rd arg.
I though it would be more consistent to have offset and count, like in all read method.