### PR TITLE
lzfse decompression support (RunType 0x80000007)

### DIFF
--- a/src/DMGDecompressor.h
+++ b/src/DMGDecompressor.h
@@ -11,6 +11,7 @@ protected:
 	DMGDecompressor(std::shared_ptr<Reader> reader);
 	int readSome(char** ptr);
 	void processed(int bytes);
+	uint64_t readerLength() const { return m_reader->length(); }
 public:
 	virtual ~DMGDecompressor() {}
 	virtual int32_t decompress(void* output, int32_t count, int64_t offset) = 0;

--- a/src/DMGPartition.cpp
+++ b/src/DMGPartition.cpp
@@ -117,6 +117,10 @@ int32_t DMGPartition::readRun(void* buf, int32_t runIndex, uint64_t offsetInSect
 		case RunType::Zlib:
 		case RunType::Bzip2:
 		case RunType::ADC:
+		case RunType::LZFSE:
+#ifndef COMPILE_WITH_LZFSE
+			throw function_not_implemented_error("LZFSE is not yet supported");
+#endif
 		{
 			std::unique_ptr<DMGDecompressor> decompressor;
 			std::shared_ptr<Reader> subReader;

--- a/src/dmg.h
+++ b/src/dmg.h
@@ -83,6 +83,7 @@ enum class RunType : uint32_t
 	ADC = 0x80000004,
 	Zlib = 0x80000005,
 	Bzip2 = 0x80000006,
+	LZFSE = 0x80000007,
 	Comment = 0x7ffffffe,
 	Terminator = 0xffffffff
 };


### PR DESCRIPTION
[Lzfse](https://github.com/lzfse/lzfse) support. I'm not really sure if we need COMPILE_WITH_LZFSE define, it should be by default, many DMG images already feature this compression.