### PR TITLE
throw "LZFSE is not yet supported" misplaced.

### DIFF
--- a/src/DMGPartition.cpp
+++ b/src/DMGPartition.cpp
@@ -114,13 +114,13 @@ int32_t DMGPartition::readRun(void* buf, int32_t runIndex, uint64_t offsetInSect
 		case RunType::Raw:
 			//std::cout << "Raw\n";
 			return m_disk->read(buf, count, be(run->compOffset) + be(m_table->dataStart) + offsetInSector);
-		case RunType::Zlib:
-		case RunType::Bzip2:
-		case RunType::ADC:
 		case RunType::LZFSE:
 #ifndef COMPILE_WITH_LZFSE
 			throw function_not_implemented_error("LZFSE is not yet supported");
 #endif
+		case RunType::Zlib:
+		case RunType::Bzip2:
+		case RunType::ADC:
 		{
 			std::unique_ptr<DMGDecompressor> decompressor;
 			std::shared_ptr<Reader> subReader;


### PR DESCRIPTION
`throw function_not_implemented_error("LZFSE is not yet supported");` append for all compression type.