### PR TITLE
HFSCatalogBTree::stat didn't follow node forward link, missing some files.

### DIFF
--- a/src/HFSBTree.h
+++ b/src/HFSBTree.h
@@ -29,15 +29,15 @@ public:
 	typedef int (*KeyComparator)(const Key* indexKey, const Key* desiredKey);
 
 	// Used when searching for an exact key (e.g. a specific file in a folder)
-	HFSBTreeNode findLeafNode(const Key* indexKey, KeyComparator comp, bool wildcard = false);
+	std::shared_ptr<HFSBTreeNode> findLeafNode(const Key* indexKey, KeyComparator comp, bool wildcard = false);
 
 	// Sued when searching for an inexact key (e.g. when listing a folder)
 	// Return value includes the leaf node where the comparator returns true for the first time when approaching from the right,
 	// and all following nodes for which the comparator returns true as well.
-	std::vector<HFSBTreeNode> findLeafNodes(const Key* indexKey, KeyComparator comp);
+	std::vector<std::shared_ptr<HFSBTreeNode>> findLeafNodes(const Key* indexKey, KeyComparator comp);
 
 protected:
-	HFSBTreeNode traverseTree(int nodeIndex, const Key* indexKey, KeyComparator comp, bool wildcard);
+	std::shared_ptr<HFSBTreeNode> traverseTree(int nodeIndex, const Key* indexKey, KeyComparator comp, bool wildcard);
 	void walkTree(int nodeIndex);
 protected:
 	std::shared_ptr<HFSFork> m_fork;

--- a/src/HFSBTreeNode.h
+++ b/src/HFSBTreeNode.h
@@ -14,22 +14,23 @@ public:
 	HFSBTreeNode()
 	: m_descriptor(nullptr), m_nodeSize(0), m_firstRecordOffset(nullptr)
 	{
-	}
-	
-	HFSBTreeNode(const std::vector<uint8_t>& descriptorData, uint16_t nodeSize)
-	: m_descriptorData(descriptorData), m_nodeSize(nodeSize), m_firstRecordOffset(nullptr)
-	{
-		initFromBuffer();
+		#ifdef DEBUG
+			m_nodeIndex = 0;
+		#endif
 	}
 	
 	HFSBTreeNode(std::shared_ptr<Reader> treeReader, uint32_t nodeIndex, uint16_t nodeSize)
 	: m_nodeSize(nodeSize)
 	{
+		#ifdef DEBUG
+			m_nodeIndex = nodeIndex;
+		#endif
 		m_descriptorData.resize(nodeSize);
 		
-		if (treeReader->read(&m_descriptorData[0], nodeSize, nodeSize*nodeIndex) < nodeSize)
-			throw std::runtime_error("Short read of BTree node");
-		
+		int32_t read = treeReader->read(&m_descriptorData[0], nodeSize, nodeSize*nodeIndex);
+		if (read < nodeSize)
+			throw std::runtime_error("Short read of BTree node. "+std::to_string(read)+" bytes read instead of "+std::to_string(nodeSize));
+
 		initFromBuffer();
 	}
 	
@@ -40,6 +41,9 @@ public:
 	
 	HFSBTreeNode& operator=(const HFSBTreeNode& that)
 	{
+		#ifdef DEBUG
+			m_nodeIndex = that.m_nodeIndex;
+		#endif
 		m_descriptorData = that.m_descriptorData;
 		m_nodeSize = that.m_nodeSize;
 		initFromBuffer();
@@ -194,6 +198,9 @@ private:
 	std::vector<uint8_t> m_descriptorData;
 	uint16_t m_nodeSize;
 	uint16_t* m_firstRecordOffset;
+	#ifdef DEBUG
+		uint32_t m_nodeIndex;
+	#endif
 };
 
 #endif

--- a/src/HFSCatalogBTree.h
+++ b/src/HFSCatalogBTree.h
@@ -16,7 +16,11 @@ public:
 	// using HFSBTree::HFSBTree;
 	HFSCatalogBTree(std::shared_ptr<HFSFork> fork, HFSVolume* volume, CacheZone* zone);
 
-	int listDirectory(const std::string& path, std::map<std::string, HFSPlusCatalogFileOrFolder>& contents);
+	int listDirectory(const std::string& path, std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>>& contents);
+	
+	std::shared_ptr<HFSPlusCatalogFileOrFolder> findHFSPlusCatalogFileOrFolderForParentIdAndName(HFSCatalogNodeID parentID, const std::string &elem);
+
+
 	int stat(std::string path, HFSPlusCatalogFileOrFolder* s);
 	int openFile(const std::string& path, std::shared_ptr<Reader>& forkOut, bool resourceFork = false);
 
@@ -27,19 +31,19 @@ public:
 
 	static time_t appleToUnixTime(uint32_t apple);
 protected:
-	HFSPlusCatalogFileOrFolder* findRecordForParentAndName(const HFSBTreeNode& leafNode, HFSCatalogNodeID cnid, const std::string& name);
 	std::string readSymlink(HFSPlusCatalogFile* file);
 
-	// does not clear the result argument
-	void findRecordForParentAndName(const HFSBTreeNode& leafNode, HFSCatalogNodeID cnid, std::map<std::string, HFSPlusCatalogFileOrFolder*>& result, const std::string& name = std::string());
 private:
-	static int caseInsensitiveComparator(const Key* indexKey, const Key* desiredKey);
+	void appendNameAndHFSPlusCatalogFileOrFolderFromLeafForParentId(std::shared_ptr<HFSBTreeNode> leafNodePtr, HFSCatalogNodeID cnid, std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>>& map);
+	void appendNameAndHFSPlusCatalogFileOrFolderFromLeafForParentIdAndName(std::shared_ptr<HFSBTreeNode> leafNodePtr, HFSCatalogNodeID cnid, const std::string& name, std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>>& map);
+
+static int caseInsensitiveComparator(const Key* indexKey, const Key* desiredKey);
 	static int caseSensitiveComparator(const Key* indexKey, const Key* desiredKey);
 	static int idOnlyComparator(const Key* indexKey, const Key* desiredKey);
 	static void fixEndian(HFSPlusCatalogFileOrFolder& ff);
 	static void replaceChars(std::string& str, char oldChar, char newChar);
 	
-	HFSBTreeNode findHFSBTreeNodeForParentIdAndName(HFSCatalogNodeID parentID, const std::string &elem);
+	std::shared_ptr<HFSBTreeNode> findHFSBTreeNodeForParentIdAndName(HFSCatalogNodeID parentID, const std::string &elem);
 
 	void dumpTree(int nodeIndex, int depth) const;
 private:

--- a/src/HFSExtentsOverflowBTree.cpp
+++ b/src/HFSExtentsOverflowBTree.cpp
@@ -11,7 +11,7 @@ HFSExtentsOverflowBTree::HFSExtentsOverflowBTree(std::shared_ptr<HFSFork> fork, 
 void HFSExtentsOverflowBTree::findExtentsForFile(HFSCatalogNodeID cnid, bool resourceFork, uint32_t startBlock, std::vector<HFSPlusExtentDescriptor>& extraExtents)
 {
 	HFSPlusExtentKey key;
-	std::vector<HFSBTreeNode> leaves;
+	std::vector<std::shared_ptr<HFSBTreeNode>> leaves;
 	bool first = true;
 
 	key.forkType = resourceFork ? 0xff : 0;
@@ -19,8 +19,9 @@ void HFSExtentsOverflowBTree::findExtentsForFile(HFSCatalogNodeID cnid, bool res
 
 	leaves = findLeafNodes((Key*) &key, cnidComparator);
 
-	for (const HFSBTreeNode& leaf : leaves)
+	for (std::shared_ptr<HFSBTreeNode> leafPtr : leaves)
 	{
+		HFSBTreeNode& leaf = *leafPtr;
 		for (int i = 0; i < leaf.recordCount(); i++)
 		{
 			HFSPlusExtentKey* recordKey = leaf.getRecordKey<HFSPlusExtentKey>(i);

--- a/src/HFSHighLevelVolume.cpp
+++ b/src/HFSHighLevelVolume.cpp
@@ -37,7 +37,7 @@ static bool string_endsWith(const std::string& str, const std::string& what)
 
 std::map<std::string, struct stat> HFSHighLevelVolume::listDirectory(const std::string& path)
 {
-	std::map<std::string, HFSPlusCatalogFileOrFolder> contents;
+	std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>> contents;
 	std::map<std::string, struct stat> rv;
 	int err;
 
@@ -49,7 +49,7 @@ std::map<std::string, struct stat> HFSHighLevelVolume::listDirectory(const std::
 	for (auto it = contents.begin(); it != contents.end(); it++)
 	{
 		struct stat st;
-		hfs_nativeToStat_decmpfs(it->second, &st, string_endsWith(it->first, RESOURCE_FORK_SUFFIX));
+		hfs_nativeToStat_decmpfs(*(it->second), &st, string_endsWith(it->first, RESOURCE_FORK_SUFFIX));
 
 		rv[it->first] = st;
 	}


### PR DESCRIPTION
To find a record, it may be needed to traverse node forward link like HFSBTree::findLeafNodes does.

HFSCatalogBTree::stat now follow the same logic (logic that was moved in HFSCatalogBTree::findHFSPlusCatalogFileOrFolderForParentIdAndName), HFSCatalogBTree::findLeafNodes, then looking for record in all these leaves and checking that no more than one is found.

To avoid memory problem like I had, I switched to return std::shared_ptr<HFSBTreeNode> instead of HFSBTreeNode, and std::shared_ptr<HFSPlusCatalogFileOrFolder> instead of HFSPlusCatalogFileOrFolder (these shared ptr retain the node while exposing the record).
This also avoid a lot of copy constructor.