### PR TITLE
CacheZone object are now shared_ptr.

### DIFF
--- a/src/CachedReader.cpp
+++ b/src/CachedReader.cpp
@@ -7,7 +7,7 @@
 
 //#define NO_CACHE
 
-CachedReader::CachedReader(std::shared_ptr<Reader> reader, CacheZone* zone, const std::string& tag)
+CachedReader::CachedReader(std::shared_ptr<Reader> reader, std::shared_ptr<CacheZone> zone, const std::string& tag)
 : m_reader(reader), m_zone(zone), m_tag(tag)
 {
 }

--- a/src/CachedReader.h
+++ b/src/CachedReader.h
@@ -7,7 +7,7 @@
 class CachedReader : public Reader
 {
 public:
-	CachedReader(std::shared_ptr<Reader> reader, CacheZone* zone, const std::string& tag);
+	CachedReader(std::shared_ptr<Reader> reader, std::shared_ptr<CacheZone> zone, const std::string& tag);
 	
 	virtual int32_t read(void* buf, int32_t count, uint64_t offset) override;
 	virtual uint64_t length() override;
@@ -15,7 +15,7 @@ private:
 	void nonCachedRead(void* buf, int32_t count, uint64_t offset);
 private:
 	std::shared_ptr<Reader> m_reader;
-	CacheZone* m_zone;
+	std::shared_ptr<CacheZone> m_zone;
 	const std::string m_tag;
 };
 

--- a/src/DMGDisk.cpp
+++ b/src/DMGDisk.cpp
@@ -15,7 +15,7 @@
 #include "exceptions.h"
 
 DMGDisk::DMGDisk(std::shared_ptr<Reader> reader)
-	: m_reader(reader), m_zone(40000)
+	: m_reader(reader), m_zone(std::make_shared<CacheZone>(40000))
 {
 	uint64_t offset = m_reader->length();
 
@@ -244,11 +244,11 @@ std::shared_ptr<Reader> DMGDisk::readerForPartition(int index)
 					m_reader->length() - data_offset));
 
 				return std::shared_ptr<Reader>(
-						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(r, table)), &m_zone, partName.str())
+						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(r, table)), m_zone, partName.str())
 						);
 			} else {
 				return std::shared_ptr<Reader>(
-						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(m_reader, table)), &m_zone, partName.str())
+						new CachedReader(std::shared_ptr<Reader>(new DMGPartition(m_reader, table)), m_zone, partName.str())
 						);
 			}
 		}

--- a/src/DMGDisk.h
+++ b/src/DMGDisk.h
@@ -29,7 +29,7 @@ private:
 	std::vector<Partition> m_partitions;
 	UDIFResourceFile m_udif;
 	xmlDocPtr m_kolyXML;
-	CacheZone m_zone;
+	std::shared_ptr<CacheZone> m_zone;
 };
 
 #endif

--- a/src/HFSAttributeBTree.cpp
+++ b/src/HFSAttributeBTree.cpp
@@ -4,7 +4,7 @@
 #include <unicode/unistr.h>
 #include "unichar.h"
 using icu::UnicodeString;
-HFSAttributeBTree::HFSAttributeBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone)
+HFSAttributeBTree::HFSAttributeBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone)
 : HFSBTree(fork, zone, "Attribute")
 {
 }

--- a/src/HFSAttributeBTree.h
+++ b/src/HFSAttributeBTree.h
@@ -11,7 +11,7 @@
 class HFSAttributeBTree : protected HFSBTree
 {
 public:
-	HFSAttributeBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone);
+	HFSAttributeBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone);
 	
 	typedef std::map<std::string, std::vector<uint8_t>> AttributeMap;
 	

--- a/src/HFSBTree.cpp
+++ b/src/HFSBTree.cpp
@@ -11,7 +11,7 @@
 #include "CacheZone.h"
 #include "exceptions.h"
 
-HFSBTree::HFSBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone, const char* cacheTag)
+HFSBTree::HFSBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone, const char* cacheTag)
 : m_fork(fork)
 {
 	BTNodeDescriptor desc0;

--- a/src/HFSBTree.h
+++ b/src/HFSBTree.h
@@ -13,7 +13,7 @@
 class HFSBTree
 {
 public:
-	HFSBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone, const char* cacheTag);
+	HFSBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone, const char* cacheTag);
 
 	struct Key
 	{

--- a/src/HFSCatalogBTree.cpp
+++ b/src/HFSCatalogBTree.cpp
@@ -10,7 +10,7 @@ static const int MAX_SYMLINKS = 50;
 
 extern UConverter *g_utf16be;
 
-HFSCatalogBTree::HFSCatalogBTree(std::shared_ptr<HFSFork> fork, HFSVolume* volume, CacheZone* zone)
+HFSCatalogBTree::HFSCatalogBTree(std::shared_ptr<HFSFork> fork, HFSVolume* volume, std::shared_ptr<CacheZone> zone)
 	: HFSBTree(fork, zone, "Catalog"), m_volume(volume), m_hardLinkDirID(0)
 {
 	HFSPlusCatalogFileOrFolder ff;
@@ -265,7 +265,6 @@ int HFSCatalogBTree::stat(std::string path, HFSPlusCatalogFileOrFolder* s)
 
 	return 0;
 }
-extern int mustbreak;
 
 void HFSCatalogBTree::appendNameAndHFSPlusCatalogFileOrFolderFromLeafForParentId(std::shared_ptr<HFSBTreeNode> leafNodePtr, HFSCatalogNodeID cnid, std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>>& map)
 {

--- a/src/HFSCatalogBTree.h
+++ b/src/HFSCatalogBTree.h
@@ -14,7 +14,7 @@ class HFSCatalogBTree : protected HFSBTree
 {
 public:
 	// using HFSBTree::HFSBTree;
-	HFSCatalogBTree(std::shared_ptr<HFSFork> fork, HFSVolume* volume, CacheZone* zone);
+	HFSCatalogBTree(std::shared_ptr<HFSFork> fork, HFSVolume* volume, std::shared_ptr<CacheZone> zone);
 
 	int listDirectory(const std::string& path, std::map<std::string, std::shared_ptr<HFSPlusCatalogFileOrFolder>>& contents);
 	

--- a/src/HFSExtentsOverflowBTree.cpp
+++ b/src/HFSExtentsOverflowBTree.cpp
@@ -3,7 +3,7 @@
 #include "exceptions.h"
 #include <stdexcept>
 
-HFSExtentsOverflowBTree::HFSExtentsOverflowBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone)
+HFSExtentsOverflowBTree::HFSExtentsOverflowBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone)
 	: HFSBTree(fork, zone, "ExtentsOverflow")
 {
 }

--- a/src/HFSExtentsOverflowBTree.h
+++ b/src/HFSExtentsOverflowBTree.h
@@ -9,7 +9,7 @@
 class HFSExtentsOverflowBTree : protected HFSBTree
 {
 public:
-	HFSExtentsOverflowBTree(std::shared_ptr<HFSFork> fork, CacheZone* zone);
+	HFSExtentsOverflowBTree(std::shared_ptr<HFSFork> fork, std::shared_ptr<CacheZone> zone);
 	void findExtentsForFile(HFSCatalogNodeID cnid, bool resourceFork, uint32_t startBlock, std::vector<HFSPlusExtentDescriptor>& extraExtents);
 private:
 	static int cnidComparator(const Key* indexKey, const Key* desiredKey);

--- a/src/HFSVolume.h
+++ b/src/HFSVolume.h
@@ -27,8 +27,8 @@ public:
 	
 	static bool isHFSPlus(std::shared_ptr<Reader> reader);
 	
-	inline CacheZone* getFileZone() { return &m_fileZone; }
-	inline CacheZone* getBtreeZone() { return &m_btreeZone; }
+	inline std::shared_ptr<CacheZone> getFileZone() { return m_fileZone; }
+	inline std::shared_ptr<CacheZone> getBtreeZone() { return m_btreeZone; }
 private:
 	void processEmbeddedHFSPlus(HFSMasterDirectoryBlock* block);
 private:
@@ -37,7 +37,7 @@ private:
 	HFSExtentsOverflowBTree* m_overflowExtents;
 	HFSAttributeBTree* m_attributes;
 	HFSPlusVolumeHeader m_header;
-	CacheZone m_fileZone, m_btreeZone;
+	std::shared_ptr<CacheZone> m_fileZone, m_btreeZone;
 	
 	friend class HFSBTree;
 	friend class HFSFork;


### PR DESCRIPTION
Some CacheZone object were shared, but could be destroyed.
For example, once you called DMGDisk::readerForPartition, you can now
delete DMGDisk and only keep the Reader object.

Took the occasion to remove unused mustbreak integer.