### PR TITLE
Warning removal.

### DIFF
--- a/src/FileReader.cpp
+++ b/src/FileReader.cpp
@@ -34,7 +34,7 @@ int32_t FileReader::read(void* buf, int32_t count, uint64_t offset)
 	
 	static_assert(sizeof(off_t) == 8, "off_t is too small");
 	
-	return ::pread(m_fd, buf, count, offset);
+	return (int32_t)::pread(m_fd, buf, count, offset); // safe cast, pread returned value is < count
 }
 
 uint64_t FileReader::length()

--- a/src/GPTDisk.cpp
+++ b/src/GPTDisk.cpp
@@ -38,7 +38,6 @@ bool GPTDisk::isGPTDisk(std::shared_ptr<Reader> reader)
 std::string GPTDisk::makeGUID(const GPT_GUID& guid)
 {
 	std::stringstream ss;
-	int pos = 0;
 
 	ss << std::hex << std::uppercase;
 	ss << std::setw(8) << std::setfill('0') << guid.data1;

--- a/src/HFSCatalogBTree.cpp
+++ b/src/HFSCatalogBTree.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <cstring>
 using icu::UnicodeString;
-static const int MAX_SYMLINKS = 50;
+//static const int MAX_SYMLINKS = 50;
 
 extern UConverter *g_utf16be;
 

--- a/src/HFSHighLevelVolume.cpp
+++ b/src/HFSHighLevelVolume.cpp
@@ -8,6 +8,7 @@
 #include "exceptions.h"
 #include "decmpfs.h"
 #include <assert.h>
+#include <limits>
 
 static const char* RESOURCE_FORK_SUFFIX = "#..namedfork#rsrc";
 static const char* XATTR_RESOURCE_FORK = "com.apple.ResourceFork";
@@ -267,11 +268,12 @@ std::vector<uint8_t> HFSHighLevelVolume::getXattr(const std::string& path, const
 			
 		if (file->length() == 0)
 			throw attribute_not_found_error();
+		if (file->length() > std::numeric_limits<int>::max())
+			throw io_error("Attribute too big");
 
-		rv = std::min<int>(std::numeric_limits<int>::max(), file->length());
-		output.resize(rv);
+		output.resize(file->length());
 
-		file->read(&output[0], rv, 0);
+		file->read(&output[0], int32_t(file->length()), 0);
 	}
 	else if (name == XATTR_FINDER_INFO)
 	{

--- a/src/MemoryReader.cpp
+++ b/src/MemoryReader.cpp
@@ -8,10 +8,12 @@ MemoryReader::MemoryReader(const uint8_t* start, size_t length)
 
 int32_t MemoryReader::read(void* buf, int32_t count, uint64_t offset)
 {
+	if ( count < 0 )
+		return -1;
 	if (offset > m_data.size())
 		return 0;
-	if (count+offset > m_data.size())
-		count = m_data.size() - offset;
+	if (count > m_data.size() - offset) // here, offset is >= m_data.size()  =>  m_data.size()-offset >= 0.   (Do not test like ' if (offset+count > be(m_fork.logicalSize)) ', offset+count could overflow)
+		count = int32_t(m_data.size() - offset); // here, m_data.size()-offset >= 0 AND < count  =>  m_data.size()-offset < INT32_MAX, cast is safe
 	
 	memcpy(buf, &m_data[offset], count);
 	return count;

--- a/src/SubReader.cpp
+++ b/src/SubReader.cpp
@@ -7,10 +7,12 @@ SubReader::SubReader(std::shared_ptr<Reader> parent, uint64_t offset, uint64_t s
 
 int32_t SubReader::read(void* buf, int32_t count, uint64_t offset)
 {
+	if ( count < 0 )
+		return -1;
 	if (offset > m_size)
 		return 0;
-	if (offset+count > m_size)
-		count = m_size - offset;
+	if (count > m_size - offset) // here, offset is >= m_size  =>  m_size-offset >= 0
+		count = int32_t(m_size - offset); // here, m_size-offset >= 0 AND < count  =>  m_size-offset < INT32_MAX, cast is safe
 	
 	return m_parent->read(buf, count, offset + m_offset);
 }

--- a/src/adc.cpp
+++ b/src/adc.cpp
@@ -110,8 +110,8 @@ int adc_decompress(int in_size, uint8_t* input, int avail_size, uint8_t* output,
 		if (output_full || input_short)
 			break;
 	}
-	*bytes_written = outp - output;
-	return inp - input;
+	*bytes_written = int(outp - output); // safe cast, outp - output is < avail_size
+	return int(inp - input); // safe cast, inp - input is < in_size
 }
 
 int adc_chunk_type(char _byte)


### PR DESCRIPTION
Safe downcast, explained in comment.
1 or 2 unused var removed.
Change to uint64_t some var used for offset.

I also better protected read function with `if ( count < 0 ) return -1;`