### PR TITLE
Fix disk image mounting problems

### DIFF
--- a/src/DMGDisk.cpp
+++ b/src/DMGDisk.cpp
@@ -207,13 +207,15 @@ bool DMGDisk::base64Decode(const std::string& input, std::vector<uint8_t>& outpu
 	std::unique_ptr<char[]> buffer(new char[input.length()]);
 	int rd;
 
+    auto b64_input = input.substr(0, input.find_last_not_of("\r\t\f\v"));
+
 	b64 = BIO_new(BIO_f_base64());
-	bmem = BIO_new_mem_buf((void*) input.c_str(), input.length());
+	bmem = BIO_new_mem_buf((void*) b64_input.c_str(), b64_input.length());
 	bmem = BIO_push(b64, bmem);
 	//BIO_set_flags(bmem, BIO_FLAGS_BASE64_NO_NL);
-	
-	rd = BIO_read(bmem, buffer.get(), input.length());
-	
+
+	rd = BIO_read(bmem, buffer.get(), b64_input.length());
+
 	if (rd > 0)
 		output.assign(buffer.get(), buffer.get()+rd);
 
@@ -266,4 +268,3 @@ std::shared_ptr<Reader> DMGDisk::readerForKolyBlock(int index)
 		return nullptr;
 	return std::shared_ptr<Reader>(new DMGPartition(m_reader, table));
 }
-

--- a/src/DMGDisk.cpp
+++ b/src/DMGDisk.cpp
@@ -68,7 +68,7 @@ void DMGDisk::loadKoly(const UDIFResourceFile& koly)
 
 	// select all partition dictionaries with partition ID >= 0
 	xpathObj = xmlXPathEvalExpression((const xmlChar*) "/plist/dict/key[text()='resource-fork']/following-sibling::dict[1]/key[text()='blkx']"
-			"/following-sibling::array[1]/dict[key[text()='ID']/following-sibling::string[text() >= 0]]", xpathContext);
+			"/following-sibling::array[1]/dict[key[text()='ID']/following-sibling::string[1][text() >= 0]]", xpathContext);
 
 	if (xpathObj && xpathObj->nodesetval)
 		simpleWayOK = loadPartitionElements(xpathContext, xpathObj->nodesetval);


### PR DESCRIPTION
This fixes many (most?) of the problems encountered when mounting certain disk images using `hdiutil` within a Darling instance.

The root problem is the base 64 decoder (provided by SSL library) getting confused by lines with trailing whitespace. Interestingly, the issue only seems to affect the Darling side, due to using a different SSL library.