### PR TITLE
docs: add notes to install library dependencies on some linux distributions, cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # darling-dmg
 
-<a href="http://teamcity.dolezel.info/viewType.html?buildTypeId=DarlingDmg_Build&guest=1">
-<img src="http://teamcity.dolezel.info/app/rest/builds/buildType:(id:DarlingDmg_Build)/statusIcon"/>
-</a>
-
 This project allows ordinary users to directly mount OS X disk images under Linux via FUSE. darling-dmg is part of Darling - http://www.darlinghq.org
 
 Without darling-dmg, the only way to do this would be to manually extract the DMG file, become root and mount the HFS+ filesystem as root. This is slow, wasteful and may even crash your system. The project's author has seen the Linux HFS+ implementation cause kernel crashes.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,19 @@ Read only access only.
 
 ## Build Requirements
 
-`darling-dmg` requires a C++11-capable compiler, CMake >3.10 and `make` alongside its dependencies. Below are common ways to install them.
+| Dependency | Required version     | Notes                              |
+|------------|----------------------|------------------------------------|
+| GCC/Clang  | >5 (GCC), >3 (Clang) | Compiler with C++11 support        |
+| CMake      | 3.10                 | Build system                       |
+| pkg-config |                      | Library-agnostic package detection |
+| OpenSSL    |                      | Base64 decoding                    |
+| Bzip2      |                      | Decompression                      |
+| Zlib       |                      | Decompression                      |
+| FUSE       | 2.x (not 3.x)        | Userspace filesystem support       |
+| libicu     |                      | Unicode support                    |
+| libxml2    |                      | XML (property list) parsing        |
+
+`darling-dmg` requires a C++11-capable compiler, CMake >3.10 and `make` alongside the remaining dependencies mentioned above. Below are common ways to install library dependencies.
 
 On Fedora (and derivatives):
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ You need the development packages for following libraries: fuse, icu, openssl, z
 
 ## Usage
 
-    darling-dmg <file-to-mount> <where-to-mount> [FUSE arguments]
+```
+darling-dmg <file-to-mount> <where-to-mount> [FUSE arguments]
+```
 
 ### Accessing resource forks
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,25 @@ Read only access only.
 
 ## Build Requirements
 
-You need the development packages for following libraries: fuse, icu, openssl, zlib, bzip2.
+`darling-dmg` requires a C++11-capable compiler, CMake >3.10 and `make` alongside its dependencies. Below are common ways to install them.
+
+On Fedora (and derivatives):
+
+```bash
+sudo dnf install fuse-devel bzip2-devel libicu-devel libxml2-devel openssl-devel zlib-devel pkgconf
+```
+
+On Debian (and derivatives):
+
+```bash
+sudo apt-get install libfuse-dev libbz2-dev libicu-dev libxml2-dev libssl-dev libz-dev pkg-config
+```
+
+On Alpine Linux:
+
+```bash
+sudo apk add fuse-dev bzip2-dev icu-dev libxml2-dev openssl-dev zlib-dev pkgconf
+```
 
 ## Usage
 


### PR DESCRIPTION
## Notes

I've opted to exclude installing the bare minimum development tools from the documentation as there isn't a *uniform* way to do that across distributions.

Not to mention that distros may have completely different attitudes to bundling development tools altogether, case and point `build-essentials` installing _only_ the essentials (meaning, you need to install the needed libraries yourself) on Debian but `base-devel` on Arch Linux includes practically everything stopping short of FUSE (which is why I omitted it from the `README`).

Another example is Fedora offering more up-to-date versions of compilers compared to Debian through official channels.

Developers may opt to use their own compiler of choice or a version differing from what the distro offers, as you commonly have to do for downloading recent releases of Clang/LLVM from https://apt.llvm.org/, for example, on Debian and its derivatives.

I've also decided to exclude `git` as strictly speaking, it's not needed for building `darling-dmg`. A source dump will eliminate the need for Git altogether (at least as long as you only plan on building and not contributing through Git).