### PR TITLE
CMakeLists.txt: Fix build on modern *nix systems w/C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+cmake_policy(SET CMP0167 NEW)
 project(darling-dmg)
 
-cmake_minimum_required(VERSION 3.13)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(dmg_sources
 	src/unichar.cpp
@@ -41,7 +45,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	"${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 
 add_definitions(-D_FILE_OFFSET_BITS=64)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -ggdb -O0")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ggdb -O0")
 
 include(FindLibXml2)
 
@@ -124,7 +128,7 @@ else (NOT DARLING)
 		${FUSE_INCLUDE_DIRS}
 	)
 
-	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -nostdinc")
+	SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdinc")
 
 	wrap_elf(fuse libfuse.so)
 


### PR DESCRIPTION
This fixes #104

- Use C++17 in `CMakeLists.txt`
- Use "`NEW`" `BoostConfig.cmake` policy ([`CMP0167`][1])
- Change ordering of `project()` after `cmake_minimum_required()` - Similar to fix described in #102

> [!NOTE]
> 
> For those who can't wait for this PR to be merged, but need a working `darling-dmg` on affected Arch-based distro family systems:
> 
> See this forked [`PKGBUILD` which includes this patch][2]

[1]: https://cmake.org/cmake/help/latest/policy/CMP0167.html
[2]: https://gitlab.archlinux.org/trinitronx/darling-dmg-git/-/merge_requests/1/diffs